### PR TITLE
Fix cache getting broken on items without length property

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ module.exports = function(tilelive, options) {
   var locker = lockingCache({
     max: 1024 * 1024 * options.size, // convert to MB
     length: function(val) {
-      return val[0] ? val[0].length : 1;
+      return (val[0] && val[0].length) ? val[0].length : 1;
     },
     maxAge: 6 * 3600e3 // 6 hours
   });


### PR DESCRIPTION
The `length` function should always return a number.
At the moment, it returns `undefined` for certain types of items (e.g. `getInfo` jsons), which do not have the `length` property.
The LRU fails on this when evaluating used memory, since `undefined + number = NaN` and `NaN` is always smaller than the max cache size and the cache grows to infinity (and can result in crash if too many requests are made in the 6 hour window (defined by the `maxAge` of items)).

This PR trivially fixes this by returning `1` as the size of items without the `length` property.