### PR TITLE
Fix the calculation of maxAge

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ var CacheCollector = function(locker, makeKey) {
           })
           .shift();
 
-    maxAge = parseInt(maxAge) || null;
+    maxAge = parseInt(maxAge) * 1000 || null;
 
     // populate the cache
     if (error == null &&

--- a/index.js
+++ b/index.js
@@ -60,9 +60,11 @@ var CacheCollector = function(locker, makeKey) {
           })
           .shift();
 
+    maxAge = parseInt(maxAge) || null;
+
     // populate the cache
     if (error == null &&
-        (maxAge == null || (maxAge | 0) > 0)) {
+        (maxAge == null || maxAge > 0)) {
       locker.cache.set(key, data, maxAge);
     }
 


### PR DESCRIPTION
While using this package I noticed a problem with setting the `maxAge` of a cache entry.

Before this fix, `maxAge` was of type string which would cause problems as the underlying cache would never evict the item.

![Screenshot from 2020-02-26 13-25-10](https://user-images.githubusercontent.com/151346/75346181-6f15d400-589e-11ea-9fbd-8c0f6c1720fe.png)

Additionally, Cache-Control expresses its time in seconds but the cache works on milliseconds, so the value is converted.

Thanks for this module!